### PR TITLE
Persist pathname when updating location

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ Url.prototype.apply = function(params){
         params = '?' + params;
     }
 
-    locationBar.update(params, {trigger: true});
+    locationBar.update(location.pathname + params, {trigger: true});
 }
 
 Url.prototype.set = function(param, value){


### PR DESCRIPTION
Before this fork, an update to url parameters (through the `set` method or anything that triggered `apply`) would strip the path of the url to the root. This is because `location-bar` expects a path as well as the parameters. Now update includes the current location pathname.

Relevant `location-bar` documentation: https://github.com/KidkArolis/location-bar#example-usage 